### PR TITLE
[Delivery] Update frontend FTP target to root domain webspace

### DIFF
--- a/.github/workflows/deploy-frontend-on-main-merge.yml
+++ b/.github/workflows/deploy-frontend-on-main-merge.yml
@@ -61,4 +61,4 @@ jobs:
           protocol: ftps
           port: 21
           local-dir: ./apps/frontend/dist/
-          server-dir: /www/htdocs/w01f67fb/saas.sebastian-schult.net/
+          server-dir: /www/htdocs/w01f67fb/sebastian-schult.net/

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ docker compose --env-file .env.production -f docker-compose.prod.yml up -d backe
 
 Current deployment target path in workflow:
 
-- `/www/htdocs/w01f67fb/saas.sebastian-schult.net/`
+- `/www/htdocs/w01f67fb/sebastian-schult.net/`
 
 ### Workflow behavior
 


### PR DESCRIPTION
## Summary
- update frontend FTPS deploy target directory to 
- keep frontend auto-deploy on merge to main

## Why
The current main workflow still deploys to the previous subdomain target path. This PR applies the final target path for the root domain webspace.