### PR TITLE
[Delivery] Fix frontend FTP target path

### DIFF
--- a/.github/workflows/deploy-frontend-on-main-merge.yml
+++ b/.github/workflows/deploy-frontend-on-main-merge.yml
@@ -61,4 +61,5 @@ jobs:
           protocol: ftps
           port: 21
           local-dir: ./apps/frontend/dist/
-          server-dir: /www/htdocs/w01f67fb/sebastian-schult.net/
+          server-dir: /sebastian-schult.net/
+          state-name: .ftp-deploy-sync-state-root-domain.json

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ docker compose --env-file .env.production -f docker-compose.prod.yml up -d backe
 
 Current deployment target path in workflow:
 
-- `/www/htdocs/w01f67fb/sebastian-schult.net/`
+- `/sebastian-schult.net/`
 
 ### Workflow behavior
 


### PR DESCRIPTION
## Summary
- switch frontend deployment target to the FTP-relative root domain path 
- use a new deploy state file so the next run uploads fresh files into that visible FileZilla directory

## Why
ALL-INKL/FileZilla shows the root domain webspace as , while the previous workflow used the absolute server path. This aligns the workflow with the visible FTP directory.