### PR TITLE
feat(prisma): add tenants table migration (#14)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
-# Prisma
-apps/backend/prisma/migrations/
-
 # Local data
 postgres-data/
 redis-data/

--- a/apps/backend/prisma/migrations/20260518142000_create_tenants_table/migration.sql
+++ b/apps/backend/prisma/migrations/20260518142000_create_tenants_table/migration.sql
@@ -1,0 +1,21 @@
+-- CreateEnum
+CREATE TYPE "TenantPlan" AS ENUM ('basic', 'pro', 'business');
+
+-- CreateEnum
+CREATE TYPE "TenantStatus" AS ENUM ('active', 'suspended', 'cancelled');
+
+-- CreateTable
+CREATE TABLE "tenants" (
+    "id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "plan" "TenantPlan" NOT NULL DEFAULT 'basic',
+    "status" "TenantStatus" NOT NULL DEFAULT 'active',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tenants_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tenants_slug_key" ON "tenants"("slug");

--- a/apps/backend/prisma/migrations/migration_lock.toml
+++ b/apps/backend/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"


### PR DESCRIPTION
## Summary
- add Prisma migration lock file for PostgreSQL
- add migration for tenants table with UUID primary key
- add TenantPlan and TenantStatus enums and default values
- enforce unique constraint on slug
- unignore Prisma migrations in .gitignore so migration history is versioned

## Validation
- DATABASE_URL=postgresql://postgres:postgres@localhost:5432/huepfburgen_saas npm run prisma:validate -w @huepf/backend

Closes #14