### PR TITLE
chore(project): automate ticket status transitions

### DIFF
--- a/.github/workflows/project-status-on-pr-open.yml
+++ b/.github/workflows/project-status-on-pr-open.yml
@@ -1,9 +1,11 @@
-name: Project Status On Merge
+name: Project Status On PR Open
 
 on:
   pull_request:
     types:
-      - closed
+      - opened
+      - reopened
+      - ready_for_review
     branches:
       - develop
       - main
@@ -11,10 +13,10 @@ on:
 permissions:
   contents: read
   repository-projects: write
+  pull-requests: read
 
 jobs:
-  move-ticket-to-test:
-    if: ${{ github.event.pull_request.merged == true }}
+  move-ticket-to-review:
     runs-on: ubuntu-latest
     steps:
       - name: Validate project automation token
@@ -26,7 +28,7 @@ jobs:
             exit 1
           fi
 
-      - name: Move linked issue to Test
+      - name: Move linked issue to Review
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
@@ -34,29 +36,30 @@ jobs:
             try {
               const projectId = "PVT_kwHOCUUiJM4BRvo_";
               const statusFieldId = "PVTSSF_lAHOCUUiJM4BRvo_zg_e3NI";
-              const testOptionId = "a4c0af78";
+              const reviewOptionId = "f769e6a8";
 
               const pr = context.payload.pull_request;
               const headBranch = pr.head.ref;
               const title = pr.title ?? "";
               const body = pr.body ?? "";
 
-              // Prefer ticket number from branch pattern: "11-some-title".
               let issueNumber = null;
-              let branchMatch = headBranch.match(/^(\d+)-/);
-              if (branchMatch) {
-                issueNumber = Number(branchMatch[1]);
+
+              // Ticket branch pattern: "14-some-title".
+              let match = headBranch.match(/^(\d+)-/);
+              if (match) {
+                issueNumber = Number(match[1]);
               }
 
-              // Support Codex branch naming like "codex/issue-14-something".
+              // Codex branch pattern: "codex/issue-14-some-title".
               if (!issueNumber) {
-                branchMatch = headBranch.match(/^codex\/issue-(\d+)(?:-|$)/);
-                if (branchMatch) {
-                  issueNumber = Number(branchMatch[1]);
+                match = headBranch.match(/^codex\/issue-(\d+)(?:-|$)/);
+                if (match) {
+                  issueNumber = Number(match[1]);
                 }
               }
 
-              // Fallback: parse references like "#11" from title/body.
+              // Fallback: parse "#14" from title/body.
               if (!issueNumber) {
                 const textMatch = `${title}\n${body}`.match(/#(\d+)/);
                 if (textMatch) {
@@ -65,7 +68,7 @@ jobs:
               }
 
               if (!issueNumber) {
-                core.info(`No issue number found for merged PR #${pr.number}. Skipping.`);
+                core.info(`No issue number found for PR #${pr.number}. Skipping.`);
                 return;
               }
 
@@ -154,13 +157,13 @@ jobs:
 
               await github.graphql(
                 `
-                mutation($projectId: ID!, $itemId: ID!, $statusFieldId: ID!, $testOptionId: String!) {
+                mutation($projectId: ID!, $itemId: ID!, $statusFieldId: ID!, $reviewOptionId: String!) {
                   updateProjectV2ItemFieldValue(
                     input: {
                       projectId: $projectId
                       itemId: $itemId
                       fieldId: $statusFieldId
-                      value: { singleSelectOptionId: $testOptionId }
+                      value: { singleSelectOptionId: $reviewOptionId }
                     }
                   ) {
                     projectV2Item {
@@ -169,10 +172,10 @@ jobs:
                   }
                 }
                 `,
-                { projectId, itemId, statusFieldId, testOptionId }
+                { projectId, itemId, statusFieldId, reviewOptionId }
               );
 
-              core.info(`Moved issue #${issueNumber} to Test.`);
+              core.info(`Moved issue #${issueNumber} to Review.`);
             } catch (error) {
               const message = error?.message ?? String(error);
               if (message.includes("Resource not accessible by integration")) {
@@ -181,5 +184,5 @@ jobs:
                 );
                 return;
               }
-              core.setFailed(`Project merge automation failed: ${message}`);
+              core.setFailed(`Project PR-open automation failed: ${message}`);
             }

--- a/.github/workflows/project-status-on-push.yml
+++ b/.github/workflows/project-status-on-push.yml
@@ -12,7 +12,7 @@ permissions:
   repository-projects: write
 
 jobs:
-  move-ticket-to-review:
+  move-ticket-to-in-progress:
     runs-on: ubuntu-latest
     steps:
       - name: Validate project automation token
@@ -24,7 +24,7 @@ jobs:
             exit 1
           fi
 
-      - name: Move linked issue to Review
+      - name: Move linked issue to In Progress
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
@@ -32,19 +32,59 @@ jobs:
             try {
               const projectId = "PVT_kwHOCUUiJM4BRvo_";
               const statusFieldId = "PVTSSF_lAHOCUUiJM4BRvo_zg_e3NI";
-              const reviewOptionId = "f769e6a8";
+              const inProgressOptionId = "10b8ed08";
 
               const branch = context.ref.replace("refs/heads/", "");
-              const match = branch.match(/^(\d+)-/);
+              const owner = context.repo.owner;
+              const repo = context.repo.repo;
 
-              if (!match) {
-                core.info(`Branch '${branch}' does not start with an issue number. Skipping.`);
+              // If there is already an open PR for this branch, do not move
+              // the issue back from Review/Test to In Progress on subsequent pushes.
+              const headRefWithOwner = `${owner}:${branch}`;
+              const existingPr = await github.rest.pulls.list({
+                owner,
+                repo,
+                state: "open",
+                head: headRefWithOwner,
+                per_page: 1
+              });
+
+              if (existingPr.data.length > 0) {
+                core.info(`Open PR exists for '${branch}'. Skipping In Progress update.`);
                 return;
               }
 
-              const issueNumber = Number(match[1]);
-              const owner = context.repo.owner;
-              const repo = context.repo.repo;
+              let issueNumber = null;
+              let match = branch.match(/^(\d+)-/);
+              if (match) {
+                issueNumber = Number(match[1]);
+              }
+
+              // Support Codex branch naming like "codex/issue-14-something".
+              if (!issueNumber) {
+                match = branch.match(/^codex\/issue-(\d+)(?:-|$)/);
+                if (match) {
+                  issueNumber = Number(match[1]);
+                }
+              }
+
+              // Fallback: parse issue reference from pushed commit messages.
+              if (!issueNumber) {
+                const commits = context.payload.commits ?? [];
+                for (const commit of commits) {
+                  const text = `${commit.message ?? ""}`;
+                  const issueMatch = text.match(/#(\d+)/);
+                  if (issueMatch) {
+                    issueNumber = Number(issueMatch[1]);
+                    break;
+                  }
+                }
+              }
+
+              if (!issueNumber) {
+                core.info(`No issue number found from branch '${branch}' or commit messages. Skipping.`);
+                return;
+              }
 
               const issueData = await github.graphql(
                 `
@@ -129,13 +169,13 @@ jobs:
 
               await github.graphql(
                 `
-                mutation($projectId: ID!, $itemId: ID!, $statusFieldId: ID!, $reviewOptionId: String!) {
+                mutation($projectId: ID!, $itemId: ID!, $statusFieldId: ID!, $inProgressOptionId: String!) {
                   updateProjectV2ItemFieldValue(
                     input: {
                       projectId: $projectId
                       itemId: $itemId
                       fieldId: $statusFieldId
-                      value: { singleSelectOptionId: $reviewOptionId }
+                      value: { singleSelectOptionId: $inProgressOptionId }
                     }
                   ) {
                     projectV2Item {
@@ -144,10 +184,10 @@ jobs:
                   }
                 }
                 `,
-                { projectId, itemId, statusFieldId, reviewOptionId }
+                { projectId, itemId, statusFieldId, inProgressOptionId }
               );
 
-              core.info(`Moved issue #${issueNumber} to Review.`);
+              core.info(`Moved issue #${issueNumber} to In Progress.`);
             } catch (error) {
               const message = error?.message ?? String(error);
               if (message.includes("Resource not accessible by integration")) {

--- a/AGENT.md
+++ b/AGENT.md
@@ -12,6 +12,19 @@ Repository-level instructions for development agents.
 - Work ticket-first from GitHub issues.
 - Keep implementation focused on the selected ticket.
 
+### Mandatory branch and merge flow
+
+Use this delivery flow for implementation tickets:
+
+1. Create a feature branch from `develop`.
+2. Open the ticket PR from feature branch to `develop`.
+3. After review and validation, merge `develop` into `main` in a separate integration step.
+
+Important:
+
+- Do not open regular feature PRs directly to `main`.
+- `main` is only updated through the controlled `develop` -> `main` merge flow.
+
 ### Mandatory project status transitions
 
 When working with the GitHub Project board, use this status flow:

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,28 @@
+# AGENT.md
+
+Repository-level instructions for development agents.
+
+## Language and documentation
+
+- Explain implementation steps in German for the main developer.
+- Keep technical documentation and code comments in English.
+
+## Ticket workflow
+
+- Work ticket-first from GitHub issues.
+- Keep implementation focused on the selected ticket.
+
+### Mandatory project status transitions
+
+When working with the GitHub Project board, use this status flow:
+
+1. `Ready` -> `In Progress` when work starts on the ticket.
+2. `In Progress` -> `Review` when a PR for the ticket is opened.
+3. `Review` -> `Test` when the ticket PR is merged.
+
+## Branch naming for automation
+
+Preferred branch names so project automation can resolve ticket numbers:
+
+- `<issue-number>-short-description`
+- `codex/issue-<issue-number>-short-description`


### PR DESCRIPTION
## Summary
- add repository-level AGENT.md with mandatory status flow: Ready -> In Progress -> Review -> Test
- update push automation to move linked issue to In Progress while no PR is open
- add PR-open automation to move linked issue to Review
- update merge automation to move linked issue to Test for merges into develop/main
- support branch patterns `<issue>-...` and `codex/issue-<issue>-...`

## Notes
- all project status automations require `PROJECT_AUTOMATION_TOKEN` (classic PAT with repo + project scope)
- architecture/docs/agent.md is ignored by git, so AGENT.md was added at repo root for versioned instructions