### PR TITLE
feat(prisma): add locations table migration (#16)

### DIFF
--- a/apps/backend/prisma/migrations/20260518154000_create_locations_table/migration.sql
+++ b/apps/backend/prisma/migrations/20260518154000_create_locations_table/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "locations" (
+    "id" UUID NOT NULL,
+    "tenant_id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "street" TEXT,
+    "house_number" TEXT,
+    "postal_code" TEXT,
+    "city" TEXT,
+    "notes" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "locations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "locations_tenant_id_idx" ON "locations"("tenant_id");
+
+-- AddForeignKey
+ALTER TABLE "locations"
+ADD CONSTRAINT "locations_tenant_id_fkey"
+FOREIGN KEY ("tenant_id")
+REFERENCES "tenants"("id")
+ON DELETE CASCADE
+ON UPDATE CASCADE;


### PR DESCRIPTION
## Summary
- add Prisma SQL migration for locations table
- include tenant foreign key with cascade delete/update
- add tenant_id index for tenant-scoped access

## Validation
- npm run prisma:format -w @huepf/backend
- DATABASE_URL='postgresql://user:pass@localhost:5432/huepf' npm run prisma:validate -w @huepf/backend

Closes #16