### PR TITLE
[#22] Create equipment_unavailability table and migration

### DIFF
--- a/apps/backend/prisma/migrations/20260520103000_create_equipment_unavailability_table/migration.sql
+++ b/apps/backend/prisma/migrations/20260520103000_create_equipment_unavailability_table/migration.sql
@@ -1,0 +1,38 @@
+-- CreateTable
+CREATE TABLE "equipment_unavailability" (
+    "id" UUID NOT NULL,
+    "tenant_id" UUID NOT NULL,
+    "equipment_id" UUID NOT NULL,
+    "start_date" DATE NOT NULL,
+    "end_date" DATE NOT NULL,
+    "reason" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "equipment_unavailability_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "equipment_unavailability_date_range_chk" CHECK ("end_date" >= "start_date")
+);
+
+-- CreateIndex
+CREATE INDEX "equipment_unavailability_tenant_id_idx"
+ON "equipment_unavailability"("tenant_id");
+
+-- CreateIndex
+CREATE INDEX "equipment_unavailability_tenant_id_equipment_id_start_date_end_date_idx"
+ON "equipment_unavailability"("tenant_id", "equipment_id", "start_date", "end_date");
+
+-- AddForeignKey
+ALTER TABLE "equipment_unavailability"
+ADD CONSTRAINT "equipment_unavailability_tenant_id_fkey"
+FOREIGN KEY ("tenant_id")
+REFERENCES "tenants"("id")
+ON DELETE CASCADE
+ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "equipment_unavailability"
+ADD CONSTRAINT "equipment_unavailability_equipment_id_fkey"
+FOREIGN KEY ("equipment_id")
+REFERENCES "equipment"("id")
+ON DELETE CASCADE
+ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -246,7 +246,7 @@ model EquipmentUnavailability {
   equipment Equipment @relation(fields: [equipmentId], references: [id], onDelete: Cascade)
 
   @@index([tenantId])
-  @@index([equipmentId, startDate, endDate])
+  @@index([tenantId, equipmentId, startDate, endDate])
   @@map("equipment_unavailability")
 }
 


### PR DESCRIPTION
## Summary\n- add migration for `equipment_unavailability`\n- enforce date-range check constraint (`end_date >= start_date`)\n- add tenant + equipment + period index for overlap/conflict queries\n\n## Validation\n- npm run prisma:format -w @huepf/backend\n- DATABASE_URL="postgresql://user:pass@localhost:5432/db" npm run prisma:validate -w @huepf/backend\n\nRelated to #22