### PR TITLE
feat(db): add updated_at trigger strategy for MVP tables (#24)

### DIFF
--- a/apps/backend/prisma/README.md
+++ b/apps/backend/prisma/README.md
@@ -63,3 +63,14 @@ npm run prisma:studio -w @huepf/backend
 - Keep migrations small and ticket-focused.
 - Prefer additive schema changes for MVP progression.
 - Use descriptive migration names for easier review and rollback planning.
+
+## `updated_at` strategy
+
+`updated_at` is maintained with a layered approach:
+
+- Prisma models use `@updatedAt` for normal ORM writes.
+- A database trigger function (`set_updated_at_timestamp`) is applied to all mutable MVP tables as a safety net for non-Prisma SQL updates.
+
+Verification guidance:
+
+- Run a row update (via Prisma or SQL) and confirm `updated_at` changes automatically.

--- a/apps/backend/prisma/migrations/20260520122000_add_updated_at_triggers/migration.sql
+++ b/apps/backend/prisma/migrations/20260520122000_add_updated_at_triggers/migration.sql
@@ -1,0 +1,63 @@
+-- Keep updated_at in sync at DB level for all mutable MVP tables.
+-- This complements Prisma's @updatedAt and also covers non-Prisma updates.
+CREATE OR REPLACE FUNCTION set_updated_at_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = CURRENT_TIMESTAMP;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_set_updated_at_tenants ON "tenants";
+CREATE TRIGGER trg_set_updated_at_tenants
+BEFORE UPDATE ON "tenants"
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at_timestamp();
+
+DROP TRIGGER IF EXISTS trg_set_updated_at_users ON "users";
+CREATE TRIGGER trg_set_updated_at_users
+BEFORE UPDATE ON "users"
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at_timestamp();
+
+DROP TRIGGER IF EXISTS trg_set_updated_at_locations ON "locations";
+CREATE TRIGGER trg_set_updated_at_locations
+BEFORE UPDATE ON "locations"
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at_timestamp();
+
+DROP TRIGGER IF EXISTS trg_set_updated_at_equipment_categories ON "equipment_categories";
+CREATE TRIGGER trg_set_updated_at_equipment_categories
+BEFORE UPDATE ON "equipment_categories"
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at_timestamp();
+
+DROP TRIGGER IF EXISTS trg_set_updated_at_equipment ON "equipment";
+CREATE TRIGGER trg_set_updated_at_equipment
+BEFORE UPDATE ON "equipment"
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at_timestamp();
+
+DROP TRIGGER IF EXISTS trg_set_updated_at_customers ON "customers";
+CREATE TRIGGER trg_set_updated_at_customers
+BEFORE UPDATE ON "customers"
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at_timestamp();
+
+DROP TRIGGER IF EXISTS trg_set_updated_at_bookings ON "bookings";
+CREATE TRIGGER trg_set_updated_at_bookings
+BEFORE UPDATE ON "bookings"
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at_timestamp();
+
+DROP TRIGGER IF EXISTS trg_set_updated_at_booking_items ON "booking_items";
+CREATE TRIGGER trg_set_updated_at_booking_items
+BEFORE UPDATE ON "booking_items"
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at_timestamp();
+
+DROP TRIGGER IF EXISTS trg_set_updated_at_equipment_unavailability ON "equipment_unavailability";
+CREATE TRIGGER trg_set_updated_at_equipment_unavailability
+BEFORE UPDATE ON "equipment_unavailability"
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at_timestamp();


### PR DESCRIPTION
## Summary
- add a Prisma migration with a reusable PostgreSQL trigger function to auto-maintain updated_at
- apply BEFORE UPDATE triggers to all mutable MVP tables
- document the layered strategy (Prisma @updatedAt + DB safety net) in Prisma README

## Validation
- DATABASE_URL='postgresql://postgres:postgres@localhost:5432/huepfburgen_saas' npm run prisma:validate -w @huepf/backend
- npm run prisma:format -w @huepf/backend

## Ticket
- Closes #24