### PR TITLE
[Epic 3] Implement password hashing strategy (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,13 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/huepfburgen_saas
 
 - Tenant context is resolved from JWT, never trusted from payload.
 - All business tables include `tenant_id`.
+- Password hashing uses `scrypt` with per-password random salts.
 - Do not commit `.env` files or secrets.
+
+### Demo auth credentials (local placeholder flow)
+
+- owner: `owner@demo-huepfburgen.local` / `owner-demo-password`
+- staff: `staff@demo-huepfburgen.local` / `staff-demo-password`
 
 ## Deployment (GitHub Actions)
 

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -2,24 +2,58 @@ import type { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
 import { HttpError } from "../utils/http-error.js";
 import { USER_ROLES } from "@huepf/shared-types";
+import { hashPassword, verifyPassword } from "../utils/password.js";
 
 const loginBodySchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
 
+const demoUsers = [
+  {
+    id: "demo-owner-id",
+    tenantId: "demo-tenant-id",
+    email: "owner@demo-huepfburgen.local",
+    role: USER_ROLES[0],
+    password: "owner-demo-password"
+  },
+  {
+    id: "demo-staff-id",
+    tenantId: "demo-tenant-id",
+    email: "staff@demo-huepfburgen.local",
+    role: USER_ROLES[2],
+    password: "staff-demo-password"
+  }
+] as const;
+
 const authRoutes: FastifyPluginAsync = async (app) => {
+  const demoUsersWithHashes = await Promise.all(
+    demoUsers.map(async (user) => ({
+      ...user,
+      passwordHash: await hashPassword(user.password)
+    }))
+  );
+
   app.post("/auth/login", async (request) => {
     const body = loginBodySchema.parse(request.body);
+    const normalizedEmail = body.email.toLowerCase();
 
-    // Placeholder auth flow: replace with DB-backed user lookup and password hash compare.
-    const role = body.email.includes("owner") ? USER_ROLES[0] : USER_ROLES[2];
+    const user = demoUsersWithHashes.find(
+      (candidate) => candidate.email === normalizedEmail
+    );
+
+    if (!user || !(await verifyPassword(body.password, user.passwordHash))) {
+      throw new HttpError(401, "INVALID_CREDENTIALS", "Invalid email or password");
+    }
+
+    // Placeholder auth flow: replace demo users with DB-backed user lookup.
+    // Password validation already uses the shared hash strategy.
 
     const token = app.jwt.sign({
-      id: "demo-user-id",
-      tenantId: "demo-tenant-id",
-      email: body.email,
-      role
+      id: user.id,
+      tenantId: user.tenantId,
+      email: user.email,
+      role: user.role
     });
 
     return {

--- a/apps/backend/src/utils/password.ts
+++ b/apps/backend/src/utils/password.ts
@@ -1,0 +1,107 @@
+import { randomBytes, scrypt, timingSafeEqual } from "node:crypto";
+
+const HASH_ALGORITHM = "scrypt";
+const SCRYPT_N = 16384;
+const SCRYPT_R = 8;
+const SCRYPT_P = 1;
+const KEY_LENGTH = 64;
+const SALT_LENGTH = 16;
+
+const deriveKey = (
+  password: string,
+  salt: Buffer,
+  options: { N: number; r: number; p: number }
+) =>
+  new Promise<Buffer>((resolve, reject) => {
+    scrypt(password, salt, KEY_LENGTH, options, (error, derivedKey) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve(derivedKey as Buffer);
+    });
+  });
+
+export const hashPassword = async (password: string): Promise<string> => {
+  const salt = randomBytes(SALT_LENGTH);
+  const derivedKey = await deriveKey(password, salt, {
+    N: SCRYPT_N,
+    r: SCRYPT_R,
+    p: SCRYPT_P
+  });
+
+  return [
+    HASH_ALGORITHM,
+    String(SCRYPT_N),
+    String(SCRYPT_R),
+    String(SCRYPT_P),
+    salt.toString("base64"),
+    derivedKey.toString("base64")
+  ].join("$");
+};
+
+export const verifyPassword = async (
+  password: string,
+  passwordHash: string
+): Promise<boolean> => {
+  const parts = passwordHash.split("$");
+
+  if (parts.length !== 6) {
+    return false;
+  }
+
+  const [algorithm, nValue, rValue, pValue, saltBase64, keyBase64] = parts;
+
+  if (algorithm !== HASH_ALGORITHM) {
+    return false;
+  }
+
+  const parsedN = Number(nValue);
+  const parsedR = Number(rValue);
+  const parsedP = Number(pValue);
+
+  if (
+    !Number.isInteger(parsedN) ||
+    !Number.isInteger(parsedR) ||
+    !Number.isInteger(parsedP) ||
+    parsedN <= 1 ||
+    parsedR <= 0 ||
+    parsedP <= 0
+  ) {
+    return false;
+  }
+
+  let salt: Buffer;
+  let expectedKey: Buffer;
+
+  try {
+    salt = Buffer.from(saltBase64, "base64");
+    expectedKey = Buffer.from(keyBase64, "base64");
+  } catch {
+    return false;
+  }
+
+  if (salt.length === 0 || expectedKey.length !== KEY_LENGTH) {
+    return false;
+  }
+
+  const derivedKey = await new Promise<Buffer>((resolve, reject) => {
+    scrypt(
+      password,
+      salt,
+      expectedKey.length,
+      { N: parsedN, r: parsedR, p: parsedP },
+      (error, key) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(key as Buffer);
+      }
+    );
+  });
+
+  return timingSafeEqual(expectedKey, derivedKey);
+};


### PR DESCRIPTION
## Summary
- add a reusable password hashing utility based on scrypt + per-password salt
- wire the auth login placeholder flow to validate passwords via the shared hash strategy
- document local demo credentials and security baseline updates

## Validation
- npm run typecheck -w @huepf/backend
- npm run lint -w @huepf/backend

Closes #29