### PR TITLE
feat(auth): implement database-backed login endpoint (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/huepfburgen_saas
 - Password hashing uses `scrypt` with per-password random salts.
 - Do not commit `.env` files or secrets.
 
-### Demo auth credentials (local placeholder flow)
+### Demo auth credentials (local seed data)
 
 - owner: `owner@demo-huepfburgen.local` / `owner-demo-password`
 - staff: `staff@demo-huepfburgen.local` / `staff-demo-password`

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -1,65 +1,63 @@
 import type { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
 import { HttpError } from "../utils/http-error.js";
-import { USER_ROLES } from "@huepf/shared-types";
-import { hashPassword, verifyPassword } from "../utils/password.js";
+import { env } from "../config/env.js";
+import { verifyPassword } from "../utils/password.js";
 
 const loginBodySchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
 
-const demoUsers = [
-  {
-    id: "demo-owner-id",
-    tenantId: "demo-tenant-id",
-    email: "owner@demo-huepfburgen.local",
-    role: USER_ROLES[0],
-    password: "owner-demo-password"
-  },
-  {
-    id: "demo-staff-id",
-    tenantId: "demo-tenant-id",
-    email: "staff@demo-huepfburgen.local",
-    role: USER_ROLES[2],
-    password: "staff-demo-password"
-  }
-] as const;
-
 const authRoutes: FastifyPluginAsync = async (app) => {
-  const demoUsersWithHashes = await Promise.all(
-    demoUsers.map(async (user) => ({
-      ...user,
-      passwordHash: await hashPassword(user.password)
-    }))
-  );
-
   app.post("/auth/login", async (request) => {
     const body = loginBodySchema.parse(request.body);
-    const normalizedEmail = body.email.toLowerCase();
+    const normalizedEmail = body.email.trim().toLowerCase();
 
-    const user = demoUsersWithHashes.find(
-      (candidate) => candidate.email === normalizedEmail
-    );
+    const user = await app.prisma.user.findUnique({
+      where: {
+        email: normalizedEmail
+      },
+      select: {
+        id: true,
+        tenantId: true,
+        email: true,
+        role: true,
+        status: true,
+        passwordHash: true,
+        tenant: {
+          select: {
+            status: true
+          }
+        }
+      }
+    });
 
     if (!user || !(await verifyPassword(body.password, user.passwordHash))) {
       throw new HttpError(401, "INVALID_CREDENTIALS", "Invalid email or password");
     }
 
-    // Placeholder auth flow: replace demo users with DB-backed user lookup.
-    // Password validation already uses the shared hash strategy.
+    if (user.status !== "active") {
+      throw new HttpError(403, "USER_DISABLED", "User account is not active");
+    }
+
+    if (user.tenant.status !== "active") {
+      throw new HttpError(403, "TENANT_INACTIVE", "Tenant account is not active");
+    }
 
     const token = app.jwt.sign({
       id: user.id,
       tenantId: user.tenantId,
       email: user.email,
       role: user.role
+    }, {
+      expiresIn: env.JWT_EXPIRES_IN
     });
 
     return {
       accessToken: token,
       tokenType: "Bearer",
-      expiresIn: "1h"
+      expiresIn: env.JWT_EXPIRES_IN
     };
   });
 

--- a/apps/backend/src/scripts/seed.ts
+++ b/apps/backend/src/scripts/seed.ts
@@ -1,6 +1,7 @@
 import { PrismaClient, type Prisma } from "@prisma/client";
 import { config as loadEnv } from "dotenv";
 import { z } from "zod";
+import { hashPassword } from "../utils/password.js";
 
 loadEnv();
 
@@ -51,7 +52,7 @@ const seedUsers = [
     firstName: "Demo",
     lastName: "Owner",
     email: "owner@demo-huepfburgen.local",
-    passwordHash: "$seed$owner-password-not-for-production",
+    password: "owner-demo-password",
     role: "owner" as const,
     status: "active" as const
   },
@@ -61,7 +62,7 @@ const seedUsers = [
     firstName: "Demo",
     lastName: "Staff",
     email: "staff@demo-huepfburgen.local",
-    passwordHash: "$seed$staff-password-not-for-production",
+    password: "staff-demo-password",
     role: "staff" as const,
     status: "active" as const
   }
@@ -190,8 +191,15 @@ try {
       data: seedTenant
     });
 
+    const usersWithPasswordHashes = await Promise.all(
+      seedUsers.map(async ({ password, ...user }) => ({
+        ...user,
+        passwordHash: await hashPassword(password)
+      }))
+    );
+
     await tx.user.createMany({
-      data: seedUsers
+      data: usersWithPasswordHashes
     });
 
     await tx.location.createMany({


### PR DESCRIPTION
## Summary
- replace placeholder login flow with Prisma-backed user lookup
- validate password via scrypt hash verification and enforce active user/tenant checks
- seed demo users with real hashed passwords so local auth works with seeded data

## Verification
- npm run typecheck -w @huepf/backend
- npm run lint -w @huepf/backend

Closes #30