### PR TITLE
feat(auth): implement JWT generation and verification (#31)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ BACKEND_PORT=3001
 BACKEND_HOST=0.0.0.0
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/huepfburgen_saas
 JWT_SECRET=replace-with-long-random-secret
+JWT_ISSUER=huepfburgen-saas-api
+JWT_AUDIENCE=huepfburgen-saas-client
 REDIS_URL=redis://localhost:6379
 
 # Frontend

--- a/.env.production.example
+++ b/.env.production.example
@@ -10,3 +10,5 @@ REDIS_URL=redis://redis:6379
 
 JWT_SECRET=replace-with-a-long-random-secret-at-least-32-chars
 JWT_EXPIRES_IN=1h
+JWT_ISSUER=huepfburgen-saas-api
+JWT_AUDIENCE=huepfburgen-saas-client

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/huepfburgen_saas
 ## Security baseline
 
 - Tenant context is resolved from JWT, never trusted from payload.
+- JWT verification enforces `issuer` and `audience` claims.
 - All business tables include `tenant_id`.
 - Password hashing uses `scrypt` with per-password random salts.
 - Do not commit `.env` files or secrets.

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -3,5 +3,7 @@ HOST=0.0.0.0
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/huepfburgen_saas
 JWT_SECRET=replace-with-long-random-secret
 JWT_EXPIRES_IN=1h
+JWT_ISSUER=huepfburgen-saas-api
+JWT_AUDIENCE=huepfburgen-saas-client
 CORS_ORIGIN=http://localhost:5173
 REDIS_URL=redis://localhost:6379

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -10,6 +10,8 @@ const envSchema = z.object({
   DATABASE_URL: z.string().min(1),
   JWT_SECRET: z.string().min(16),
   JWT_EXPIRES_IN: z.string().default("1h"),
+  JWT_ISSUER: z.string().min(1).default("huepfburgen-saas-api"),
+  JWT_AUDIENCE: z.string().min(1).default("huepfburgen-saas-client"),
   CORS_ORIGIN: z.string().default("http://localhost:5173"),
   REDIS_URL: z.string().default("redis://localhost:6379")
 });

--- a/apps/backend/src/plugins/auth.ts
+++ b/apps/backend/src/plugins/auth.ts
@@ -1,20 +1,28 @@
 import fp from "fastify-plugin";
 import fastifyJwt from "@fastify/jwt";
-import type { AuthUser } from "@huepf/shared-types";
 import { env } from "../config/env.js";
+import { parseAuthTokenPayload } from "../utils/jwt.js";
 
 const authPlugin = fp(async (app) => {
   await app.register(fastifyJwt, {
-    secret: env.JWT_SECRET
+    secret: env.JWT_SECRET,
+    sign: {
+      iss: env.JWT_ISSUER,
+      aud: env.JWT_AUDIENCE,
+      expiresIn: env.JWT_EXPIRES_IN
+    },
+    verify: {
+      allowedIss: env.JWT_ISSUER,
+      allowedAud: env.JWT_AUDIENCE
+    }
   });
 
   app.decorateRequest("authUser", null);
 
   app.decorate("authenticate", async (request, reply) => {
     try {
-      await request.jwtVerify();
-      const payload = request.user as AuthUser;
-      request.authUser = payload;
+      const payload = await request.jwtVerify();
+      request.authUser = parseAuthTokenPayload(payload);
     } catch {
       reply.code(401).send({
         error: {

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { HttpError } from "../utils/http-error.js";
 import { env } from "../config/env.js";
 import { verifyPassword } from "../utils/password.js";
+import { createAuthTokenPayload } from "../utils/jwt.js";
 
 const loginBodySchema = z.object({
   email: z.string().email(),
@@ -45,14 +46,17 @@ const authRoutes: FastifyPluginAsync = async (app) => {
       throw new HttpError(403, "TENANT_INACTIVE", "Tenant account is not active");
     }
 
-    const token = app.jwt.sign({
-      id: user.id,
-      tenantId: user.tenantId,
-      email: user.email,
-      role: user.role
-    }, {
-      expiresIn: env.JWT_EXPIRES_IN
-    });
+    const token = app.jwt.sign(
+      createAuthTokenPayload({
+        id: user.id,
+        tenantId: user.tenantId,
+        email: user.email,
+        role: user.role
+      }),
+      {
+        expiresIn: env.JWT_EXPIRES_IN
+      }
+    );
 
     return {
       accessToken: token,

--- a/apps/backend/src/utils/jwt.ts
+++ b/apps/backend/src/utils/jwt.ts
@@ -1,0 +1,29 @@
+import { USER_ROLES, type AuthUser } from "@huepf/shared-types";
+import { z } from "zod";
+
+const authTokenPayloadSchema = z.object({
+  sub: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  email: z.string().email(),
+  role: z.enum(USER_ROLES)
+});
+
+export type AuthTokenPayload = z.infer<typeof authTokenPayloadSchema>;
+
+export const createAuthTokenPayload = (user: AuthUser): AuthTokenPayload => ({
+  sub: user.id,
+  tenantId: user.tenantId,
+  email: user.email,
+  role: user.role
+});
+
+export const parseAuthTokenPayload = (payload: unknown): AuthUser => {
+  const parsed = authTokenPayloadSchema.parse(payload);
+
+  return {
+    id: parsed.sub,
+    tenantId: parsed.tenantId,
+    email: parsed.email,
+    role: parsed.role
+  };
+};


### PR DESCRIPTION
## Summary
- add a dedicated JWT payload utility with strict schema validation
- centralize token creation for authenticated users
- enforce issuer/audience claims during JWT verification
- add JWT issuer/audience env configuration and docs

## Validation
- npm run typecheck -w @huepf/backend
- npm run lint -w @huepf/backend

Closes #31