### PR TITLE
feat(auth): add hardened auth middleware for protected routes (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/huepfburgen_saas
 
 - Tenant context is resolved from JWT, never trusted from payload.
 - JWT verification enforces `issuer` and `audience` claims.
+- Protected API routes re-validate active user and tenant state on each request.
 - All business tables include `tenant_id`.
 - Password hashing uses `scrypt` with per-password random salts.
 - Do not commit `.env` files or secrets.

--- a/apps/backend/src/plugins/auth.ts
+++ b/apps/backend/src/plugins/auth.ts
@@ -2,6 +2,7 @@ import fp from "fastify-plugin";
 import fastifyJwt from "@fastify/jwt";
 import { env } from "../config/env.js";
 import { parseAuthTokenPayload } from "../utils/jwt.js";
+import { HttpError } from "../utils/http-error.js";
 
 const authPlugin = fp(async (app) => {
   await app.register(fastifyJwt, {
@@ -19,19 +20,54 @@ const authPlugin = fp(async (app) => {
 
   app.decorateRequest("authUser", null);
 
-  app.decorate("authenticate", async (request, reply) => {
+  app.decorate("authenticate", async (request, _reply) => {
+    let tokenPayload;
+
     try {
-      const payload = await request.jwtVerify();
-      request.authUser = parseAuthTokenPayload(payload);
+      tokenPayload = parseAuthTokenPayload(await request.jwtVerify());
     } catch {
-      reply.code(401).send({
-        error: {
-          code: "UNAUTHORIZED",
-          message: "Authentication required",
-          details: []
-        }
-      });
+      throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
     }
+
+    const user = await app.prisma.user.findUnique({
+      where: {
+        tenantId_id: {
+          tenantId: tokenPayload.tenantId,
+          id: tokenPayload.id
+        }
+      },
+      select: {
+        id: true,
+        tenantId: true,
+        email: true,
+        role: true,
+        status: true,
+        tenant: {
+          select: {
+            status: true
+          }
+        }
+      }
+    });
+
+    if (!user) {
+      throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
+    }
+
+    if (user.status !== "active") {
+      throw new HttpError(403, "USER_DISABLED", "User account is not active");
+    }
+
+    if (user.tenant.status !== "active") {
+      throw new HttpError(403, "TENANT_INACTIVE", "Tenant account is not active");
+    }
+
+    request.authUser = {
+      id: user.id,
+      tenantId: user.tenantId,
+      email: user.email,
+      role: user.role
+    };
   });
 });
 


### PR DESCRIPTION
## Summary
- harden `app.authenticate` for protected routes
- verify JWT and parse typed auth payload
- re-validate active user and active tenant from database on each protected request
- populate request auth context from database-backed user data
- document protected-route revalidation behavior in security baseline

## Testing
- npm run typecheck -w @huepf/backend
- npm run lint -w @huepf/backend

## Notes
- stacked on top of #31 by design to keep auth work incremental
- closes #32