### PR TITLE
feat(auth): protect routes by tenant-aware request context (#33)

### DIFF
--- a/apps/backend/src/plugins/auth.ts
+++ b/apps/backend/src/plugins/auth.ts
@@ -1,7 +1,24 @@
 import fp from "fastify-plugin";
 import fastifyJwt from "@fastify/jwt";
+import type { FastifyReply } from "fastify";
 import { env } from "../config/env.js";
 import { parseAuthTokenPayload } from "../utils/jwt.js";
+import { HttpError } from "../utils/http-error.js";
+
+const sendAuthError = (
+  reply: FastifyReply,
+  statusCode: number,
+  code: string,
+  message: string
+) => {
+  reply.code(statusCode).send({
+    error: {
+      code,
+      message,
+      details: []
+    }
+  });
+};
 
 const authPlugin = fp(async (app) => {
   await app.register(fastifyJwt, {
@@ -18,20 +35,76 @@ const authPlugin = fp(async (app) => {
   });
 
   app.decorateRequest("authUser", null);
+  app.decorateRequest("requestContext", null);
 
   app.decorate("authenticate", async (request, reply) => {
+    let tokenUser;
+
     try {
       const payload = await request.jwtVerify();
-      request.authUser = parseAuthTokenPayload(payload);
+      tokenUser = parseAuthTokenPayload(payload);
     } catch {
-      reply.code(401).send({
-        error: {
-          code: "UNAUTHORIZED",
-          message: "Authentication required",
-          details: []
-        }
-      });
+      sendAuthError(reply, 401, "UNAUTHORIZED", "Authentication required");
+      return;
     }
+
+    const dbUser = await app.prisma.user.findUnique({
+      where: {
+        id: tokenUser.id
+      },
+      select: {
+        id: true,
+        tenantId: true,
+        email: true,
+        role: true,
+        status: true,
+        tenant: {
+          select: {
+            id: true,
+            name: true,
+            slug: true,
+            plan: true,
+            status: true
+          }
+        }
+      }
+    });
+
+    if (!dbUser || dbUser.tenantId !== tokenUser.tenantId) {
+      sendAuthError(reply, 401, "UNAUTHORIZED", "Authentication required");
+      return;
+    }
+
+    if (dbUser.status !== "active") {
+      sendAuthError(reply, 403, "USER_DISABLED", "User account is not active");
+      return;
+    }
+
+    if (dbUser.tenant.status !== "active") {
+      sendAuthError(reply, 403, "TENANT_INACTIVE", "Tenant account is not active");
+      return;
+    }
+
+    const authUser = {
+      id: dbUser.id,
+      tenantId: dbUser.tenantId,
+      email: dbUser.email,
+      role: dbUser.role
+    };
+
+    request.authUser = authUser;
+    request.requestContext = {
+      user: authUser,
+      tenant: dbUser.tenant
+    };
+  });
+
+  app.decorate("requireRequestContext", (request) => {
+    if (!request.requestContext) {
+      throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
+    }
+
+    return request.requestContext;
   });
 });
 

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -66,12 +66,11 @@ const authRoutes: FastifyPluginAsync = async (app) => {
   });
 
   app.get("/auth/me", { preHandler: app.authenticate }, async (request) => {
-    if (!request.authUser) {
-      throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
-    }
+    const context = app.requireRequestContext(request);
 
     return {
-      user: request.authUser
+      user: context.user,
+      tenant: context.tenant
     };
   });
 

--- a/apps/backend/src/types/fastify.d.ts
+++ b/apps/backend/src/types/fastify.d.ts
@@ -1,15 +1,28 @@
 import "fastify";
-import type { AuthUser } from "@huepf/shared-types";
+import type { AuthUser, TenantPlan, TenantStatus } from "@huepf/shared-types";
 import type { PrismaClient } from "@prisma/client";
 
 declare module "fastify" {
+  interface TenantRequestContext {
+    user: AuthUser;
+    tenant: {
+      id: string;
+      name: string;
+      slug: string;
+      plan: TenantPlan;
+      status: TenantStatus;
+    };
+  }
+
   interface FastifyRequest {
     authUser: AuthUser | null;
+    requestContext: TenantRequestContext | null;
   }
 
   interface FastifyInstance {
     prisma: PrismaClient;
     authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+    requireRequestContext: (request: FastifyRequest) => TenantRequestContext;
     verifyDatabaseConnection: () => Promise<void>;
   }
 }


### PR DESCRIPTION
## Summary
- add tenant-aware request context on authenticated requests
- verify JWT user against database and enforce active user/tenant status
- expose a reusable request-context guard and return tenant context on /auth/me

## Testing
- npm run typecheck -w @huepf/backend
- npm run lint -w @huepf/backend

Closes #33