### PR TITLE
fix(workflows): keep issue status automation active for stacked PRs

### DIFF
--- a/.github/workflows/project-status-on-merge.yml
+++ b/.github/workflows/project-status-on-merge.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     types:
       - closed
-    branches:
-      - develop
-      - main
 
 permissions:
   contents: read
@@ -37,9 +34,16 @@ jobs:
               const testOptionId = "a4c0af78";
 
               const pr = context.payload.pull_request;
+              const baseBranch = pr.base.ref;
               const headBranch = pr.head.ref;
               const title = pr.title ?? "";
               const body = pr.body ?? "";
+
+              // Release PRs should not move roadmap tickets.
+              if (baseBranch === "main" && headBranch === "develop") {
+                core.info("Skipping develop -> main release PR.");
+                return;
+              }
 
               // Prefer ticket number from branch pattern: "11-some-title".
               let issueNumber = null;

--- a/.github/workflows/project-status-on-pr-open.yml
+++ b/.github/workflows/project-status-on-pr-open.yml
@@ -6,9 +6,6 @@ on:
       - opened
       - reopened
       - ready_for_review
-    branches:
-      - develop
-      - main
 
 permissions:
   contents: read
@@ -39,9 +36,16 @@ jobs:
               const reviewOptionId = "f769e6a8";
 
               const pr = context.payload.pull_request;
+              const baseBranch = pr.base.ref;
               const headBranch = pr.head.ref;
               const title = pr.title ?? "";
               const body = pr.body ?? "";
+
+              // Release PRs should not move roadmap tickets.
+              if (baseBranch === "main" && headBranch === "develop") {
+                core.info("Skipping develop -> main release PR.");
+                return;
+              }
 
               let issueNumber = null;
 


### PR DESCRIPTION
## Summary
- run project-status workflows for PRs targeting any branch, not only develop/main
- keep a safety guard to skip develop -> main release PRs
- keep issue transitions to Review on PR open and Test on merge for issue branches like codex/issue-34-*

## Why
Issue status changes were skipped when PRs were opened in stacked flows, because the workflow trigger was limited to develop/main targets. This prevented expected moves to Review.

## Validation
- checked workflow diff only touches status automation files
- branch is based on up-to-date develop to avoid merge conflicts
