### PR TITLE
[Epic 3] Define role-based authorization helpers

### DIFF
--- a/apps/backend/src/plugins/auth.ts
+++ b/apps/backend/src/plugins/auth.ts
@@ -3,6 +3,7 @@ import fastifyJwt from "@fastify/jwt";
 import { env } from "../config/env.js";
 import { parseAuthTokenPayload } from "../utils/jwt.js";
 import { HttpError } from "../utils/http-error.js";
+import { assertAnyRole, assertMinimumRole } from "../utils/authorization.js";
 
 const authPlugin = fp(async (app) => {
   await app.register(fastifyJwt, {
@@ -87,6 +88,18 @@ const authPlugin = fp(async (app) => {
     }
 
     return request.requestContext;
+  });
+
+  app.decorate("authorizeRoles", (request, allowedRoles) => {
+    const context = app.requireRequestContext(request);
+    assertAnyRole(context.user.role, allowedRoles);
+    return context;
+  });
+
+  app.decorate("authorizeMinimumRole", (request, minimumRole) => {
+    const context = app.requireRequestContext(request);
+    assertMinimumRole(context.user.role, minimumRole);
+    return context;
   });
 });
 

--- a/apps/backend/src/types/fastify.d.ts
+++ b/apps/backend/src/types/fastify.d.ts
@@ -1,5 +1,5 @@
 import "fastify";
-import type { AuthUser, TenantPlan, TenantStatus } from "@huepf/shared-types";
+import type { AuthUser, TenantPlan, TenantStatus, UserRole } from "@huepf/shared-types";
 import type { PrismaClient } from "@prisma/client";
 
 declare module "fastify" {
@@ -23,6 +23,8 @@ declare module "fastify" {
     prisma: PrismaClient;
     authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
     requireRequestContext: (request: FastifyRequest) => TenantRequestContext;
+    authorizeRoles: (request: FastifyRequest, allowedRoles: readonly UserRole[]) => TenantRequestContext;
+    authorizeMinimumRole: (request: FastifyRequest, minimumRole: UserRole) => TenantRequestContext;
     verifyDatabaseConnection: () => Promise<void>;
   }
 }

--- a/apps/backend/src/utils/authorization.ts
+++ b/apps/backend/src/utils/authorization.ts
@@ -1,0 +1,45 @@
+import type { UserRole } from "@huepf/shared-types";
+import { HttpError } from "./http-error.js";
+
+const ROLE_PRIORITY: Record<UserRole, number> = {
+  viewer: 10,
+  staff: 20,
+  admin: 30,
+  owner: 40
+};
+
+const ensureNonEmptyRoles = (allowedRoles: readonly UserRole[]) => {
+  if (allowedRoles.length > 0) {
+    return;
+  }
+
+  throw new HttpError(
+    500,
+    "AUTHORIZATION_CONFIG_ERROR",
+    "Authorization helper received no allowed roles"
+  );
+};
+
+export const hasAnyRole = (role: UserRole, allowedRoles: readonly UserRole[]): boolean => {
+  ensureNonEmptyRoles(allowedRoles);
+  return allowedRoles.includes(role);
+};
+
+export const hasMinimumRole = (role: UserRole, minimumRole: UserRole): boolean =>
+  ROLE_PRIORITY[role] >= ROLE_PRIORITY[minimumRole];
+
+export const assertAnyRole = (role: UserRole, allowedRoles: readonly UserRole[]): void => {
+  if (hasAnyRole(role, allowedRoles)) {
+    return;
+  }
+
+  throw new HttpError(403, "FORBIDDEN", "Insufficient permissions");
+};
+
+export const assertMinimumRole = (role: UserRole, minimumRole: UserRole): void => {
+  if (hasMinimumRole(role, minimumRole)) {
+    return;
+  }
+
+  throw new HttpError(403, "FORBIDDEN", "Insufficient permissions");
+};

--- a/docs/working-foundation.md
+++ b/docs/working-foundation.md
@@ -25,6 +25,7 @@ This file consolidates the architecture constraints from `architecture/docs/*.md
 - Tenant users and platform admins are separate concerns.
 - Support access should use time-boxed support sessions (impersonation), not hidden permanent admin access.
 - All support sessions require a `reason` and are audit logged.
+- Backend role authorization should use shared helpers (`authorizeRoles`, `authorizeMinimumRole`) instead of ad-hoc checks in routes.
 
 ## Internationalization rules
 


### PR DESCRIPTION
## Summary
- add central role-based authorization helpers for Fastify backend
- expose authorizeRoles and authorizeMinimumRole decorators via auth plugin
- document shared authorization helper usage in working foundation

## Validation
- npm run typecheck -w @huepf/backend
- npm run lint -w @huepf/backend

Closes #35