### PR TITLE
feat(auth): protect tenant routes by role and tenant scope (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/huepfburgen_saas
 - Tenant context is resolved from JWT, never trusted from payload.
 - JWT verification enforces `issuer` and `audience` claims.
 - Protected API routes re-validate active user and tenant state on each request.
+- Role checks should use shared auth helpers (`authorizeRoles`, `authorizeMinimumRole`).
+- Tenant writes are protected by role (`owner`, `admin`) and enforced tenant scope checks.
 - All business tables include `tenant_id`.
 - Password hashing uses `scrypt` with per-password random salts.
 - Do not commit `.env` files or secrets.

--- a/apps/backend/src/plugins/auth.ts
+++ b/apps/backend/src/plugins/auth.ts
@@ -3,7 +3,7 @@ import fastifyJwt from "@fastify/jwt";
 import { env } from "../config/env.js";
 import { parseAuthTokenPayload } from "../utils/jwt.js";
 import { HttpError } from "../utils/http-error.js";
-import { assertAnyRole, assertMinimumRole } from "../utils/authorization.js";
+import { assertAnyRole, assertMinimumRole, assertSameTenant } from "../utils/authorization.js";
 
 const authPlugin = fp(async (app) => {
   await app.register(fastifyJwt, {
@@ -99,6 +99,12 @@ const authPlugin = fp(async (app) => {
   app.decorate("authorizeMinimumRole", (request, minimumRole) => {
     const context = app.requireRequestContext(request);
     assertMinimumRole(context.user.role, minimumRole);
+    return context;
+  });
+
+  app.decorate("authorizeTenant", (request, tenantId) => {
+    const context = app.requireRequestContext(request);
+    assertSameTenant(context.tenant.id, tenantId);
     return context;
   });
 });

--- a/apps/backend/src/plugins/auth.ts
+++ b/apps/backend/src/plugins/auth.ts
@@ -3,6 +3,7 @@ import fastifyJwt from "@fastify/jwt";
 import { env } from "../config/env.js";
 import { parseAuthTokenPayload } from "../utils/jwt.js";
 import { HttpError } from "../utils/http-error.js";
+import { assertAnyRole, assertMinimumRole } from "../utils/authorization.js";
 
 const authPlugin = fp(async (app) => {
   await app.register(fastifyJwt, {
@@ -87,6 +88,18 @@ const authPlugin = fp(async (app) => {
     }
 
     return request.requestContext;
+  });
+
+  app.decorate("authorizeRoles", (request, allowedRoles) => {
+    const context = app.requireRequestContext(request);
+    assertAnyRole(context.user.role, allowedRoles);
+    return context;
+  });
+
+  app.decorate("authorizeMinimumRole", (request, minimumRole) => {
+    const context = app.requireRequestContext(request);
+    assertMinimumRole(context.user.role, minimumRole);
+    return context;
   });
 });
 

--- a/apps/backend/src/routes/index.ts
+++ b/apps/backend/src/routes/index.ts
@@ -1,10 +1,12 @@
 import type { FastifyPluginAsync } from "fastify";
 import healthRoute from "./health.js";
 import authRoutes from "./auth.js";
+import tenantRoutes from "./tenant.js";
 
 const apiRoutes: FastifyPluginAsync = async (app) => {
   await app.register(healthRoute);
   await app.register(authRoutes);
+  await app.register(tenantRoutes);
 };
 
 export default apiRoutes;

--- a/apps/backend/src/routes/tenant.ts
+++ b/apps/backend/src/routes/tenant.ts
@@ -1,5 +1,4 @@
 import type { FastifyPluginAsync } from "fastify";
-import { Prisma } from "@prisma/client";
 import { z } from "zod";
 import { HttpError } from "../utils/http-error.js";
 
@@ -27,6 +26,14 @@ const updateTenantBodySchema = z
   });
 
 const tenantWriteRoles = ["owner", "admin"] as const;
+
+const isPrismaUniqueConstraintError = (error: unknown): boolean => {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return false;
+  }
+
+  return error.code === "P2002";
+};
 
 const tenantRoutes: FastifyPluginAsync = async (app) => {
   app.get("/tenant", { preHandler: app.authenticate }, async (request) => {
@@ -61,8 +68,8 @@ const tenantRoutes: FastifyPluginAsync = async (app) => {
       });
 
       return tenantResponseSchema.parse(tenant);
-    } catch (error) {
-      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+    } catch (error: unknown) {
+      if (isPrismaUniqueConstraintError(error)) {
         throw new HttpError(409, "TENANT_SLUG_ALREADY_EXISTS", "Tenant slug already exists");
       }
 

--- a/apps/backend/src/routes/tenant.ts
+++ b/apps/backend/src/routes/tenant.ts
@@ -1,0 +1,74 @@
+import type { FastifyPluginAsync } from "fastify";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+import { HttpError } from "../utils/http-error.js";
+
+const tenantResponseSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  slug: z.string().min(1),
+  plan: z.enum(["basic", "pro", "business"]),
+  status: z.enum(["active", "suspended", "cancelled"])
+});
+
+const updateTenantBodySchema = z
+  .object({
+    name: z.string().trim().min(1).max(120).optional(),
+    slug: z
+      .string()
+      .trim()
+      .min(3)
+      .max(80)
+      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+      .optional()
+  })
+  .refine((value) => value.name !== undefined || value.slug !== undefined, {
+    message: "At least one tenant field must be provided"
+  });
+
+const tenantWriteRoles = ["owner", "admin"] as const;
+
+const tenantRoutes: FastifyPluginAsync = async (app) => {
+  app.get("/tenant", { preHandler: app.authenticate }, async (request) => {
+    const context = app.requireRequestContext(request);
+    app.authorizeTenant(request, context.tenant.id);
+
+    return tenantResponseSchema.parse(context.tenant);
+  });
+
+  app.patch("/tenant", { preHandler: app.authenticate }, async (request) => {
+    const context = app.authorizeRoles(request, tenantWriteRoles);
+    app.authorizeTenant(request, context.tenant.id);
+
+    const body = updateTenantBodySchema.parse(request.body);
+
+    try {
+      const tenant = await app.prisma.tenant.update({
+        where: {
+          id: context.tenant.id
+        },
+        data: {
+          ...(body.name !== undefined ? { name: body.name } : {}),
+          ...(body.slug !== undefined ? { slug: body.slug } : {})
+        },
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          plan: true,
+          status: true
+        }
+      });
+
+      return tenantResponseSchema.parse(tenant);
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+        throw new HttpError(409, "TENANT_SLUG_ALREADY_EXISTS", "Tenant slug already exists");
+      }
+
+      throw error;
+    }
+  });
+};
+
+export default tenantRoutes;

--- a/apps/backend/src/types/fastify.d.ts
+++ b/apps/backend/src/types/fastify.d.ts
@@ -25,6 +25,7 @@ declare module "fastify" {
     requireRequestContext: (request: FastifyRequest) => TenantRequestContext;
     authorizeRoles: (request: FastifyRequest, allowedRoles: readonly UserRole[]) => TenantRequestContext;
     authorizeMinimumRole: (request: FastifyRequest, minimumRole: UserRole) => TenantRequestContext;
+    authorizeTenant: (request: FastifyRequest, tenantId: string) => TenantRequestContext;
     verifyDatabaseConnection: () => Promise<void>;
   }
 }

--- a/apps/backend/src/types/fastify.d.ts
+++ b/apps/backend/src/types/fastify.d.ts
@@ -1,5 +1,5 @@
 import "fastify";
-import type { AuthUser, TenantPlan, TenantStatus } from "@huepf/shared-types";
+import type { AuthUser, TenantPlan, TenantStatus, UserRole } from "@huepf/shared-types";
 import type { PrismaClient } from "@prisma/client";
 
 declare module "fastify" {
@@ -23,6 +23,8 @@ declare module "fastify" {
     prisma: PrismaClient;
     authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
     requireRequestContext: (request: FastifyRequest) => TenantRequestContext;
+    authorizeRoles: (request: FastifyRequest, allowedRoles: readonly UserRole[]) => TenantRequestContext;
+    authorizeMinimumRole: (request: FastifyRequest, minimumRole: UserRole) => TenantRequestContext;
     verifyDatabaseConnection: () => Promise<void>;
   }
 }

--- a/apps/backend/src/utils/authorization.ts
+++ b/apps/backend/src/utils/authorization.ts
@@ -43,3 +43,14 @@ export const assertMinimumRole = (role: UserRole, minimumRole: UserRole): void =
 
   throw new HttpError(403, "FORBIDDEN", "Insufficient permissions");
 };
+
+export const assertSameTenant = (
+  authenticatedTenantId: string,
+  requestedTenantId: string
+): void => {
+  if (authenticatedTenantId === requestedTenantId) {
+    return;
+  }
+
+  throw new HttpError(403, "TENANT_SCOPE_VIOLATION", "Cross-tenant access is not allowed");
+};

--- a/apps/backend/src/utils/authorization.ts
+++ b/apps/backend/src/utils/authorization.ts
@@ -1,0 +1,45 @@
+import type { UserRole } from "@huepf/shared-types";
+import { HttpError } from "./http-error.js";
+
+const ROLE_PRIORITY: Record<UserRole, number> = {
+  viewer: 10,
+  staff: 20,
+  admin: 30,
+  owner: 40
+};
+
+const ensureNonEmptyRoles = (allowedRoles: readonly UserRole[]) => {
+  if (allowedRoles.length > 0) {
+    return;
+  }
+
+  throw new HttpError(
+    500,
+    "AUTHORIZATION_CONFIG_ERROR",
+    "Authorization helper received no allowed roles"
+  );
+};
+
+export const hasAnyRole = (role: UserRole, allowedRoles: readonly UserRole[]): boolean => {
+  ensureNonEmptyRoles(allowedRoles);
+  return allowedRoles.includes(role);
+};
+
+export const hasMinimumRole = (role: UserRole, minimumRole: UserRole): boolean =>
+  ROLE_PRIORITY[role] >= ROLE_PRIORITY[minimumRole];
+
+export const assertAnyRole = (role: UserRole, allowedRoles: readonly UserRole[]): void => {
+  if (hasAnyRole(role, allowedRoles)) {
+    return;
+  }
+
+  throw new HttpError(403, "FORBIDDEN", "Insufficient permissions");
+};
+
+export const assertMinimumRole = (role: UserRole, minimumRole: UserRole): void => {
+  if (hasMinimumRole(role, minimumRole)) {
+    return;
+  }
+
+  throw new HttpError(403, "FORBIDDEN", "Insufficient permissions");
+};

--- a/docs/working-foundation.md
+++ b/docs/working-foundation.md
@@ -26,6 +26,7 @@ This file consolidates the architecture constraints from `architecture/docs/*.md
 - Support access should use time-boxed support sessions (impersonation), not hidden permanent admin access.
 - All support sessions require a `reason` and are audit logged.
 - Backend role authorization should use shared helpers (`authorizeRoles`, `authorizeMinimumRole`) instead of ad-hoc checks in routes.
+- Route handlers should enforce tenant scope with explicit checks (`authorizeTenant`) before tenant-bound reads or writes.
 
 ## Internationalization rules
 

--- a/docs/working-foundation.md
+++ b/docs/working-foundation.md
@@ -25,6 +25,7 @@ This file consolidates the architecture constraints from `architecture/docs/*.md
 - Tenant users and platform admins are separate concerns.
 - Support access should use time-boxed support sessions (impersonation), not hidden permanent admin access.
 - All support sessions require a `reason` and are audit logged.
+- Backend role authorization should use shared helpers (`authorizeRoles`, `authorizeMinimumRole`) instead of ad-hoc checks in routes.
 
 ## Internationalization rules
 


### PR DESCRIPTION
## Summary
- add tenant scope authorization helper (authorizeTenant) for route-level tenant isolation
- add protected tenant routes for GET /api/v1/tenant and PATCH /api/v1/tenant
- enforce role protection for tenant updates (owner, admin)
- map tenant slug uniqueness violations to 409 TENANT_SLUG_ALREADY_EXISTS
- register tenant routes in the API route tree

## Validation
- npm run typecheck -w @huepf/backend
- npm run lint -w @huepf/backend
- npm run build -w @huepf/backend

Closes #36