### PR TITLE
Issue 37: Implement equipment list endpoint with filters

### DIFF
--- a/apps/backend/src/modules/equipment/equipment.schemas.ts
+++ b/apps/backend/src/modules/equipment/equipment.schemas.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+
+const equipmentStatusValues = ["available", "reserved", "maintenance", "inactive"] as const;
+
+export const equipmentListQuerySchema = z.object({
+  search: z.preprocess((value) => {
+    if (typeof value !== "string") {
+      return value;
+    }
+
+    const trimmedValue = value.trim();
+    return trimmedValue === "" ? undefined : trimmedValue;
+  }, z.string().max(120).optional()),
+  status: z.enum(equipmentStatusValues).optional(),
+  categoryId: z.string().uuid().optional(),
+  locationId: z.string().uuid().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20)
+});
+
+export const equipmentListItemSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  description: z.string().nullable(),
+  sku: z.string().nullable(),
+  serialNumber: z.string().nullable(),
+  status: z.enum(equipmentStatusValues),
+  imageUrl: z.string().nullable(),
+  active: z.boolean(),
+  category: z
+    .object({
+      id: z.string().uuid(),
+      name: z.string().min(1)
+    })
+    .nullable(),
+  location: z
+    .object({
+      id: z.string().uuid(),
+      name: z.string().min(1)
+    })
+    .nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date()
+});
+
+export const equipmentListResponseSchema = z.object({
+  items: z.array(equipmentListItemSchema),
+  pagination: z.object({
+    page: z.number().int().min(1),
+    pageSize: z.number().int().min(1).max(100),
+    totalItems: z.number().int().min(0),
+    totalPages: z.number().int().min(0)
+  })
+});
+
+export type EquipmentListQuery = z.infer<typeof equipmentListQuerySchema>;
+export type EquipmentListResponse = z.infer<typeof equipmentListResponseSchema>;

--- a/apps/backend/src/modules/equipment/equipment.service.ts
+++ b/apps/backend/src/modules/equipment/equipment.service.ts
@@ -5,10 +5,7 @@ import {
   type EquipmentListResponse
 } from "./equipment.schemas.js";
 
-type EquipmentFindManyArgs = Parameters<PrismaClient["equipment"]["findMany"]>[0];
-type EquipmentWhereInput = NonNullable<EquipmentFindManyArgs>["where"];
-
-const createEquipmentWhereInput = (tenantId: string, query: EquipmentListQuery): EquipmentWhereInput => {
+const createEquipmentWhereInput = (tenantId: string, query: EquipmentListQuery) => {
   const search = query.search?.trim();
 
   return {
@@ -23,25 +20,25 @@ const createEquipmentWhereInput = (tenantId: string, query: EquipmentListQuery):
             {
               name: {
                 contains: search,
-                mode: "insensitive"
+                mode: "insensitive" as const
               }
             },
             {
               description: {
                 contains: search,
-                mode: "insensitive"
+                mode: "insensitive" as const
               }
             },
             {
               sku: {
                 contains: search,
-                mode: "insensitive"
+                mode: "insensitive" as const
               }
             },
             {
               serialNumber: {
                 contains: search,
-                mode: "insensitive"
+                mode: "insensitive" as const
               }
             }
           ]

--- a/apps/backend/src/modules/equipment/equipment.service.ts
+++ b/apps/backend/src/modules/equipment/equipment.service.ts
@@ -1,11 +1,14 @@
-import type { Prisma, PrismaClient } from "@prisma/client";
+import type { PrismaClient } from "@prisma/client";
 import {
   equipmentListResponseSchema,
   type EquipmentListQuery,
   type EquipmentListResponse
 } from "./equipment.schemas.js";
 
-const createEquipmentWhereInput = (tenantId: string, query: EquipmentListQuery): Prisma.EquipmentWhereInput => {
+type EquipmentFindManyArgs = Parameters<PrismaClient["equipment"]["findMany"]>[0];
+type EquipmentWhereInput = NonNullable<EquipmentFindManyArgs>["where"];
+
+const createEquipmentWhereInput = (tenantId: string, query: EquipmentListQuery): EquipmentWhereInput => {
   const search = query.search?.trim();
 
   return {

--- a/apps/backend/src/modules/equipment/equipment.service.ts
+++ b/apps/backend/src/modules/equipment/equipment.service.ts
@@ -1,0 +1,101 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+import {
+  equipmentListResponseSchema,
+  type EquipmentListQuery,
+  type EquipmentListResponse
+} from "./equipment.schemas.js";
+
+const createEquipmentWhereInput = (tenantId: string, query: EquipmentListQuery): Prisma.EquipmentWhereInput => {
+  const search = query.search?.trim();
+
+  return {
+    tenantId,
+    active: true,
+    ...(query.status !== undefined ? { status: query.status } : {}),
+    ...(query.categoryId !== undefined ? { categoryId: query.categoryId } : {}),
+    ...(query.locationId !== undefined ? { locationId: query.locationId } : {}),
+    ...(search
+      ? {
+          OR: [
+            {
+              name: {
+                contains: search,
+                mode: "insensitive"
+              }
+            },
+            {
+              description: {
+                contains: search,
+                mode: "insensitive"
+              }
+            },
+            {
+              sku: {
+                contains: search,
+                mode: "insensitive"
+              }
+            },
+            {
+              serialNumber: {
+                contains: search,
+                mode: "insensitive"
+              }
+            }
+          ]
+        }
+      : {})
+  };
+};
+
+export const listEquipment = async (
+  prisma: PrismaClient,
+  tenantId: string,
+  query: EquipmentListQuery
+): Promise<EquipmentListResponse> => {
+  const where = createEquipmentWhereInput(tenantId, query);
+  const skip = (query.page - 1) * query.pageSize;
+
+  const [items, totalItems] = await prisma.$transaction([
+    prisma.equipment.findMany({
+      where,
+      skip,
+      take: query.pageSize,
+      orderBy: [{ createdAt: "desc" }, { id: "asc" }],
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        sku: true,
+        serialNumber: true,
+        status: true,
+        imageUrl: true,
+        active: true,
+        createdAt: true,
+        updatedAt: true,
+        category: {
+          select: {
+            id: true,
+            name: true
+          }
+        },
+        location: {
+          select: {
+            id: true,
+            name: true
+          }
+        }
+      }
+    }),
+    prisma.equipment.count({ where })
+  ]);
+
+  return equipmentListResponseSchema.parse({
+    items,
+    pagination: {
+      page: query.page,
+      pageSize: query.pageSize,
+      totalItems,
+      totalPages: Math.ceil(totalItems / query.pageSize)
+    }
+  });
+};

--- a/apps/backend/src/routes/equipment.ts
+++ b/apps/backend/src/routes/equipment.ts
@@ -1,0 +1,14 @@
+import type { FastifyPluginAsync } from "fastify";
+import { equipmentListQuerySchema } from "../modules/equipment/equipment.schemas.js";
+import { listEquipment } from "../modules/equipment/equipment.service.js";
+
+const equipmentRoutes: FastifyPluginAsync = async (app) => {
+  app.get("/equipment", { preHandler: app.authenticate }, async (request) => {
+    const context = app.requireRequestContext(request);
+    const query = equipmentListQuerySchema.parse(request.query);
+
+    return listEquipment(app.prisma, context.tenant.id, query);
+  });
+};
+
+export default equipmentRoutes;

--- a/apps/backend/src/routes/index.ts
+++ b/apps/backend/src/routes/index.ts
@@ -2,11 +2,13 @@ import type { FastifyPluginAsync } from "fastify";
 import healthRoute from "./health.js";
 import authRoutes from "./auth.js";
 import tenantRoutes from "./tenant.js";
+import equipmentRoutes from "./equipment.js";
 
 const apiRoutes: FastifyPluginAsync = async (app) => {
   await app.register(healthRoute);
   await app.register(authRoutes);
   await app.register(tenantRoutes);
+  await app.register(equipmentRoutes);
 };
 
 export default apiRoutes;


### PR DESCRIPTION
## Summary
- add GET /api/v1/equipment route with auth protection
- add filter + pagination query validation using Zod (search, status, categoryId, locationId, page, pageSize)
- add tenant-safe service query with pagination metadata
- register equipment route in API router

## Validation
- npm run typecheck -w @huepf/backend
- npm run lint -w @huepf/backend

Closes #37